### PR TITLE
fix broken badge for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/milligan22963/passphrase.svg)](https://pkg.go.dev/github.com/milligan22963/passphrase)
 [![go.mod](https://img.shields.io/github/go-mod/go-version/milligan22963/passphrase)](go.mod)
 [![LICENSE](https://img.shields.io/github/license/milligan22963/passphrase)](LICENSE)
-[![Build Status](https://img.shields.io/github/workflow/status/milligan22963/passphrase/build)](https://github.com/milligan22963/passphrase/actions?query=workflow%3Abuild+branch%3Amain)
+[![Build Status](https://img.shields.io/github/workflow/status/milligan22963/passphrase/Main%20Workflow)](https://github.com/milligan22963/passphrase/actions?query=workflow%3AMain%20Workflow+branch%3Amain)
 [![Go Report Card](https://goreportcard.com/badge/github.com/milligan22963/passphrase)](https://goreportcard.com/report/github.com/milligan22963/passphrase)
 [![Codecov](https://codecov.io/gh/milligan22963/passphrase/branch/main/graph/badge.svg)](https://codecov.io/gh/milligan22963/passphrase)
 


### PR DESCRIPTION
fix the URL for the build status badge to match "Main Workflow" name of... the main workflow.